### PR TITLE
Missing parenthesis and typo

### DIFF
--- a/latex/lecture04/dl4nlp2022-lecture04.tex
+++ b/latex/lecture04/dl4nlp2022-lecture04.tex
@@ -645,7 +645,7 @@ We fine-tune parameters (word embeddings) using SGD
 	\end{itemize}
 \end{frame}
 
-\section{Evalution}
+\section{Evaluation}
 
 \begin{frame}{Word Similarity Tasks}
 	\begin{itemize}

--- a/latex/lecture07/dl4nlp2022-lecture07.tex
+++ b/latex/lecture07/dl4nlp2022-lecture07.tex
@@ -472,7 +472,7 @@ So RNNs can capture left-to-right order of input symbols
 \qquad
 \bm{\hat{y}_t} = \mathrm{softmax} \big( \bm{h_t}\bm{V} + \bm{b_{\hat{y}}} \big)
 \\
-\ell = - \frac{1}{3} (\log (0.28) + \log(0.57) + \log(0.49)
+\ell = - \frac{1}{3} (\log (0.28) + \log(0.57) + \log(0.49))
 \end{align*}
 
 %\node(y_hat_formula) at (5,-2.5) {$\bm{\hat{y}_t} = \texttt{softmax} \big( \bm{h_t}\bm{V} + \bm{b_{\hat{y}}} \big) $};


### PR DESCRIPTION
Hi, I found two small mistakes.

On the slides of lecture 4, the _evaluation_ section is misspelled.

And in lecture 7, a parenthesis is missing in the loss function on slide 12:
![image](https://user-images.githubusercontent.com/52164046/181243914-f8049634-3828-42cb-aea7-d08a489da073.png)
