### PR TITLE
Add link to recording of lecture 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ July 4, 2023
 
 July 11, 2023
 
-* [Slides as PDF](/pdf/dl4nlp2023-lecture13.pdf), [PPTX lecture slides](/pdf/dl4nlp2023-lecture13.pptx)
+* [Slides as PDF](/pdf/dl4nlp2023-lecture13.pdf), [PPTX lecture slides](/pdf/dl4nlp2023-lecture13.pptx), [YouTube recording](https://www.youtube.com/watch?v=lO2-W5l2y40)
 
  
 ## Subtitles/Close caption

--- a/latex/lecture10/dl4nlp2023-lecture10.tex
+++ b/latex/lecture10/dl4nlp2023-lecture10.tex
@@ -756,7 +756,7 @@ What if we decide to use \textbf{supervised data} -- but from various datasets?
 \begin{frame}{Takeaways}
 	
 \begin{itemize}
-	\item BERT is a pretrained language model which produces \textbf{contextualized} token representations of input TeXstudio
+	\item BERT is a pretrained language model which produces \textbf{contextualized} representations of tokens
 	\item It can be used as an \textbf{initialization} (starting point) for \textbf{fine-tuning} task-specific models
 	\begin{itemize}
 		\item Extras: [CLS] and [SEP] tokens


### PR DESCRIPTION
I added a link to the YouTube recording of lecture 13 and corrected a typo in lecture 10, where the string "TeXstudio" had made it into the slides.