### PR TITLE
Fix typos and minor errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,4 +179,4 @@ which generates the PDF in your local folder (e.g, `/tmp/slides`).
 
 ### Compiling handouts
 
-We're uploading the PDFs as presented in the lecture. You can compile the slides in a concise way using the `handout` settings. Just commment/uncomment the respective line at the beginning of the tex file of the lecture slides.
+We're uploading the PDFs as presented in the lecture. You can compile the slides in a concise way using the `handout` settings. Just comment/uncomment the respective line at the beginning of the tex file of the lecture slides.

--- a/latex/lecture04/dl4nlp2023-lecture04.tex
+++ b/latex/lecture04/dl4nlp2023-lecture04.tex
@@ -726,7 +726,7 @@ $$
 		\end{cases}
 		$$
 		
-		or \hspace{0.4em} $\mathrm{ReLU}(z) = \max(0, x)$
+		or \hspace{0.4em} $\mathrm{ReLU}(z) = \max(0, z)$
 		
 		
 			

--- a/latex/lecture04/dl4nlp2023-lecture04.tex
+++ b/latex/lecture04/dl4nlp2023-lecture04.tex
@@ -600,7 +600,7 @@ $$
 \end{block}	
 \end{frame}
 
-\begin{frame}{Background: K-L divergence (lso known as \emph{relative entropy})}
+\begin{frame}{Background: K-L divergence (also known as \emph{relative entropy})}
 	
 Let $Y$ and $\hat{Y}$ be categorical random variables over same categories, with probability distributions $P(Y)$ and $Q(\hat{Y})$
 \begin{align*}

--- a/latex/lecture05/dl4nlp2023-lecture05.tex
+++ b/latex/lecture05/dl4nlp2023-lecture05.tex
@@ -430,7 +430,7 @@ We \emph{factorize} the joint probability into a product
 	\item One factorization is very useful: left-to-right
 \end{itemize}
 $$
-\Pr(w_{1:n}) = \Pr(w_1 | \text{<s>}) \Pr (w_2 | \text{<s>}, w_1) \Pr(w_3 | \text{<s>}, w_1, w_2) \cdots \Pr(w_k | \text{<s>}, w_1, w_2, \ldots, w_{n-1})
+\Pr(w_{1:n}) = \Pr(w_1 | \text{<s>}) \Pr (w_2 | \text{<s>}, w_1) \Pr(w_3 | \text{<s>}, w_1, w_2) \cdots \Pr(w_n | \text{<s>}, w_1, w_2, \ldots, w_{n-1})
 $$
 
 \end{frame}
@@ -438,7 +438,7 @@ $$
 \begin{frame}{Simplifications in `classical' language models}
 Despite factorization, the last term of
 $
-\Pr(w_{1:n}) = \Pr(w_1 | \text{<s>}) \Pr (w_2 | \text{<s>}, w_1) \Pr(w_3 | \text{<s>}, w_1, w_2) \cdots \Pr(w_k | \text{<s>}, w_1, w_2, \ldots, w_{n-1})
+\Pr(w_{1:n}) = \Pr(w_1 | \text{<s>}) \Pr (w_2 | \text{<s>}, w_1) \Pr(w_3 | \text{<s>}, w_1, w_2) \cdots \Pr(w_n | \text{<s>}, w_1, w_2, \ldots, w_{n-1})
 $
 still depends on all the previous words of the sequence
 

--- a/latex/lecture06/dl4nlp2023-lecture06.tex
+++ b/latex/lecture06/dl4nlp2023-lecture06.tex
@@ -127,7 +127,7 @@ Technical University of Darmstadt \hfill \texttt{www.trusthlt.org} }
 
 \begin{frame}{Motivation}
 
-I give you a large corpus or plain text data
+I give you a large corpus of plain text data
 
 Can you build a model that will answer any of the `word analogy' tasks?
 
@@ -616,7 +616,7 @@ Potential obstacles
 
 \begin{itemize}
 	\item Data sparsity --- some entries in the matrix $\bm{M}$ may be incorrect because we did not observe enough data points
-	\item The explicit word vectors are of a very high dimensions (depending on the definition of context, the number of possible contexts can be in the hundreds of thousands, or even millions)
+	\item The explicit word vectors are of a very high dimension (depending on the definition of context, the number of possible contexts can be in the hundreds of thousands, or even millions)
 \end{itemize}
 
 $\to$ Dimensionality reduction techniques, e.g., singular value decomposition (SVD) for low-rank representation (we won't tackle that)
@@ -675,7 +675,7 @@ $\to$ Dimensionality reduction techniques, e.g., singular value decomposition (S
 \end{figure}
 \end{block}
 
-The rows of the embeddings matrix $\bm{E}$ learn suitable word representation in context (colums of $\bm{W^2}$ too)
+The rows of the embeddings matrix $\bm{E}$ learn suitable word representation in context (columns of $\bm{W^2}$ too)
 
 \end{frame}
 
@@ -748,7 +748,7 @@ What if we don't need probability distribution but just want to learn word embed
 	\end{tikzpicture}
 \end{figure}	
 
-For example, insted of modeling $\Pr(w_3 | w_1, w_2, \boxdot)$, we model $\Pr(w_2 | w_1,  \boxdot, w_3)$
+For example, instead of modeling $\Pr(w_3 | w_1, w_2, \boxdot)$, we model $\Pr(w_2 | w_1,  \boxdot, w_3)$
 
 \end{frame}
 
@@ -1014,7 +1014,7 @@ word2vec simplifies the neural LM by removing the hidden layer (so turning it in
 \end{figure}
 
 
-%- we have obtained the best performance on the taskintroduced in the next section by building a log-linear classifier with four future and four history words at the input, where the training criterion is to correctly classify the current (middle) word.
+%- we have obtained the best performance on the task introduced in the next section by building a log-linear classifier with four future and four history words at the input, where the training criterion is to correctly classify the current (middle) word.
 
 Variant 1: Continuous bag of words (CBOW)
 $\bm{c} = \sum_{i = 1}^{k} v(c_i)$
@@ -1091,7 +1091,7 @@ Create a set $D$ of correct word-context pairs and set $\bar{D}$ of incorrect wo
 
 The goal of the algorithm is to estimate the probability $\Pr(D = 1 | w, c)$ that the word-context pair $w, c$ comes from the correct set $D$
 
-This should be high ($1$) for for pairs from $D$ and low ($0$) for pairs from $\bar{D}$
+This should be high ($1$) for pairs from $D$ and low ($0$) for pairs from $\bar{D}$
 \end{frame}
 
 \begin{frame}{The corpus-wide loss of word2vec}
@@ -1200,7 +1200,7 @@ Popular word embedding models ignore the morphology of words, by assigning a dis
 $\to$ Model each word as a bag of character $n$-grams
 \begin{itemize}
 \item Each character $n$-gram has own embedding
-\item Word is represented as a sum of $n$-gram emeddings	
+\item Word is represented as a sum of $n$-gram embeddings	
 \end{itemize}
 
 
@@ -1338,7 +1338,7 @@ The corpora reflect human biases in the real world (cultural or otherwise)
 \begin{block}{Polysemy, context independent representation}
 Some words have obvious multiple senses
 
-A \emph{bank} may refer to a financial institution or to the side of a river, a \emph{star} may an abstract shape, a celebrity, an astronomical entity
+A \emph{bank} may refer to a financial institution or to the side of a river, a \emph{star} may be an abstract shape, a celebrity, an astronomical entity
 
 Using a single vector for all forms	is problematic
 \end{block}

--- a/latex/lecture07/dl4nlp2023-lecture07.tex
+++ b/latex/lecture07/dl4nlp2023-lecture07.tex
@@ -782,7 +782,7 @@ Fancy name for element-wise multiplication
 $\bm{z_{[i]}} = \bm{u_{[i]}} \cdot \bm{v_{[i]}}$
 \end{block}
 $
-\bm{s'} \gets \bm{g} \odot \bm{x} + (\bm{1} + \bm{g}) \odot \bm{s}
+\bm{s'} \gets \bm{g} \odot \bm{x} + (\bm{1} - \bm{g}) \odot \bm{s}
 $
 \begin{itemize}
 	\item \pause Reads the entries in $\bm{x}$ corresponding to ones in the gate, writes them to the memory
@@ -816,7 +816,7 @@ $$
 8 \\ 9 \\ 3
 \end{pmatrix}
 \\
-\bm{s'} &\gets &\bm{g} &\odot &\bm{x} &+ &(\bm{1} + \bm{g}) &\odot &\bm{s} \\
+\bm{s'} &\gets &\bm{g} &\odot &\bm{x} &+ &(\bm{1} - \bm{g}) &\odot &\bm{s} \\
 \end{aligned}
 $$
 \pause

--- a/latex/lecture09/dl4nlp2023-lecture09.tex
+++ b/latex/lecture09/dl4nlp2023-lecture09.tex
@@ -530,13 +530,13 @@ $$
 	$$
 
 	\pause
-	Each matrix $\bm{Q}, \bm{K}, \bm{V} \in R^{n \times d_m}$, where $d_m$ is the \textit{model dimension}.
+	Each matrix $\bm{Q}, \bm{K}, \bm{V} \in \mathbb{R}^{n \times d_m}$, where $d_m$ is the \textit{model dimension}.
 
 	\pause
 	\textbf{Split} each query/key/value into $h$ \textbf{heads} (aspects) by \textit{reshaping}. 
 
 	$$
-		\bm{Q}, \bm{K}, \bm{V} \in R^{n \times d_m} \to \bm{Q}, \bm{K}, \bm{V} \in {R^{n \times h \times d_m/h}}
+		\bm{Q}, \bm{K}, \bm{V} \in \mathbb{R}^{n \times d_m} \to \bm{Q}, \bm{K}, \bm{V} \in \mathbb{R}^{n \times h \times d_m/h}
 	$$
 	\pause
 	\begin{itemize}


### PR DESCRIPTION
These are some more things I found during exam preparation.
The first commit fixes some obvious typos and duplicate words.
The second fixes some minor errors (at least I believe those are errors, maybe a double check cannot hurt).
The third commit uses the mathbb command to show $\mathbb{R}$ as the real number symbol instead of $R$.